### PR TITLE
Update Dovecot to v2.2.36.3

### DIFF
--- a/data/Dockerfiles/dovecot/Dockerfile
+++ b/data/Dockerfiles/dovecot/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer "Andre Peters <andre.peters@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL C
-ENV DOVECOT_VERSION 2.3.5.1
+ENV DOVECOT_VERSION 2.2.36.3
 ENV PIGEONHOLE_VERSION 0.5.5
 
 RUN apt-get update && apt-get -y --no-install-recommends install \


### PR DESCRIPTION
Fixes CVE-2019-7524

Changelog: https://www.dovecot.org/list/dovecot-news/2019-March/000402.html

This is my first time contributing. Let me know if there's anything missing from this PR.